### PR TITLE
Fix rendering infrastructure nodes in c4 plantuml deployment diagrams

### DIFF
--- a/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
@@ -239,9 +239,9 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
         } else if (element instanceof InfrastructureNode) {
             InfrastructureNode infrastructureNode = (InfrastructureNode)element;
             if (StringUtils.isNullOrEmpty(infrastructureNode.getTechnology())) {
-                writer.writeLine(format("Deployment_Node(%s, \"%s\", $tags=\"%s\")%s", idOf(infrastructureNode), name, tagsOf(elementToWrite), url));
+                writer.writeLine(format("Deployment_Node(%s, \"%s\", $descr=\"%s\", $tags=\"%s\")%s", idOf(infrastructureNode), name, description, tagsOf(elementToWrite), url));
             } else {
-                writer.writeLine(format("Deployment_Node(%s, \"%s\", \"%s\", $tags=\"%s\")%s", idOf(infrastructureNode), name, infrastructureNode.getTechnology(), tagsOf(elementToWrite), url));
+                writer.writeLine(format("Deployment_Node(%s, \"%s\", \"%s\", \"%s\", $tags=\"%s\")%s", idOf(infrastructureNode), name, infrastructureNode.getTechnology(), description, tagsOf(elementToWrite), url));
             }
         }
 

--- a/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
@@ -241,9 +241,7 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
             if (StringUtils.isNullOrEmpty(infrastructureNode.getTechnology())) {
                 writer.writeLine(format("Deployment_Node(%s, \"%s\", $tags=\"%s\")%s", idOf(infrastructureNode), name, tagsOf(elementToWrite), url));
             } else {
-                if (StringUtils.isNullOrEmpty(infrastructureNode.getTechnology())) {
-                    writer.writeLine(format("Deployment_Node(%s, \"%s\", \"%s\", $tags=\"%s\")%s", idOf(infrastructureNode), name, infrastructureNode.getTechnology(), tagsOf(elementToWrite), url));
-                }
+                writer.writeLine(format("Deployment_Node(%s, \"%s\", \"%s\", $tags=\"%s\")%s", idOf(infrastructureNode), name, infrastructureNode.getTechnology(), tagsOf(elementToWrite), url));
             }
         }
 

--- a/src/test/java/com/structurizr/export/plantuml/C4PlantUMLDiagramExporterTests.java
+++ b/src/test/java/com/structurizr/export/plantuml/C4PlantUMLDiagramExporterTests.java
@@ -3,9 +3,7 @@ package com.structurizr.export.plantuml;
 import com.structurizr.Workspace;
 import com.structurizr.export.AbstractExporterTests;
 import com.structurizr.export.Diagram;
-import com.structurizr.model.Component;
-import com.structurizr.model.Container;
-import com.structurizr.model.SoftwareSystem;
+import com.structurizr.model.*;
 import com.structurizr.util.WorkspaceUtils;
 import com.structurizr.view.*;
 import org.junit.jupiter.api.Test;
@@ -300,4 +298,31 @@ public class C4PlantUMLDiagramExporterTests extends AbstractExporterTests {
                 "@enduml", diagram.getDefinition());
     }
 
+    @Test
+    public void test_renderInfrastructureNodeWithTechnology() {
+        Workspace workspace = new Workspace("Name", "Description");
+        DeploymentNode deploymentNode = workspace.getModel().addDeploymentNode("Deployment node");
+        deploymentNode.addInfrastructureNode("Infrastructure node", "", "technology");
+
+        DeploymentView view = workspace.getViews().createDeploymentView("key", "description");
+        view.addDefaultElements();
+
+        Diagram diagram = new C4PlantUMLExporter().export(view);
+        assertEquals("@startuml\n" +
+                "title Deployment - Default\n" +
+                "\n" +
+                "top to bottom direction\n" +
+                "\n" +
+                "!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4.puml\n" +
+                "!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml\n" +
+                "!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Deployment.puml\n" +
+                "\n" +
+                "Deployment_Node(Default.Deploymentnode, \"Deployment node\", $tags=\"Element+Deployment Node\") {\n" +
+                "  Deployment_Node(Default.Deploymentnode.Infrastructurenode, \"Infrastructure node\", \"technology\", $tags=\"Element+Infrastructure Node\")\n" +
+                "}\n" +
+                "\n" +
+                "\n" +
+                "SHOW_LEGEND()\n" +
+                "@enduml", diagram.getDefinition());
+    }
 }

--- a/src/test/java/com/structurizr/export/plantuml/C4PlantUMLDiagramExporterTests.java
+++ b/src/test/java/com/structurizr/export/plantuml/C4PlantUMLDiagramExporterTests.java
@@ -302,9 +302,9 @@ public class C4PlantUMLDiagramExporterTests extends AbstractExporterTests {
     public void test_renderInfrastructureNodeWithTechnology() {
         Workspace workspace = new Workspace("Name", "Description");
         DeploymentNode deploymentNode = workspace.getModel().addDeploymentNode("Deployment node");
-        deploymentNode.addInfrastructureNode("Infrastructure node", "", "technology");
+        deploymentNode.addInfrastructureNode("Infrastructure node", "description", "technology");
 
-        DeploymentView view = workspace.getViews().createDeploymentView("key", "description");
+        DeploymentView view = workspace.getViews().createDeploymentView("key", "view description");
         view.addDefaultElements();
 
         Diagram diagram = new C4PlantUMLExporter().export(view);
@@ -318,7 +318,7 @@ public class C4PlantUMLDiagramExporterTests extends AbstractExporterTests {
                 "!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Deployment.puml\n" +
                 "\n" +
                 "Deployment_Node(Default.Deploymentnode, \"Deployment node\", $tags=\"Element+Deployment Node\") {\n" +
-                "  Deployment_Node(Default.Deploymentnode.Infrastructurenode, \"Infrastructure node\", \"technology\", $tags=\"Element+Infrastructure Node\")\n" +
+                "  Deployment_Node(Default.Deploymentnode.Infrastructurenode, \"Infrastructure node\", \"technology\", \"description\", $tags=\"Element+Infrastructure Node\")\n" +
                 "}\n" +
                 "\n" +
                 "\n" +

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/54915-AmazonWebServicesDeployment.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/54915-AmazonWebServicesDeployment.puml
@@ -24,8 +24,8 @@ Deployment_Node(Default.AmazonWebServices, "Amazon Web Services", $tags="Element
 
     }
 
-    Deployment_Node(Default.AmazonWebServices.USEast1.ElasticLoadBalancer, "Elastic Load Balancer", $tags="Element+Infrastructure Node+Amazon Web Services - Elastic Load Balancing")
-    Deployment_Node(Default.AmazonWebServices.USEast1.Route53, "Route 53", $tags="Element+Infrastructure Node+Amazon Web Services - Route 53")
+    Deployment_Node(Default.AmazonWebServices.USEast1.ElasticLoadBalancer, "Elastic Load Balancer", $descr="", $tags="Element+Infrastructure Node+Amazon Web Services - Elastic Load Balancing")
+    Deployment_Node(Default.AmazonWebServices.USEast1.Route53, "Route 53", $descr="High available cloud DNS web service", $tags="Element+Infrastructure Node+Amazon Web Services - Route 53")
   }
 
 }

--- a/src/test/structurizr-54915-workspace.json
+++ b/src/test/structurizr-54915-workspace.json
@@ -144,6 +144,7 @@
                             {
                                 "id": "10",
                                 "tags": "Element,Infrastructure Node,Amazon Web Services - Route 53",
+                                "description": "High available cloud DNS web service",
                                 "name": "Route 53",
                                 "relationships": [
                                     {


### PR DESCRIPTION
This MR addresses two issues, related to rendering infrastructure nodes in deployment diagrams by `C4PlantUMLExporter`:

1. When a technology is specified, the infrastructure node isn't added to the PlantUML diagram.
2. The description of the infrastructure node is not rendered.