### PR TITLE
let structurizr-client only be a test-dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.structurizr:structurizr-client:1.12.2'
+    implementation 'com.structurizr:structurizr-core:1.12.2'
 
+    testImplementation 'com.structurizr:structurizr-client:1.12.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,3 @@ signing.secretKeyRingFile=/some/path
 
 ossrhUsername=username
 ossrhPassword=password
-


### PR DESCRIPTION
the export library does not need structurizr-client at runtime, it only needs it for test cases, I've therefore changed the scope.

this will reduce transitive dependencies (like httpclient) when just using structurizr-export