### PR TITLE
#2 allow to export properties to C4 PlantUML files

### DIFF
--- a/src/main/java/com/structurizr/export/plantuml/AbstractPlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/AbstractPlantUMLExporter.java
@@ -4,9 +4,7 @@ import com.structurizr.export.AbstractDiagramExporter;
 import com.structurizr.export.IndentingWriter;
 import com.structurizr.model.*;
 import com.structurizr.util.StringUtils;
-import com.structurizr.view.DynamicView;
-import com.structurizr.view.Shape;
-import com.structurizr.view.View;
+import com.structurizr.view.*;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -19,6 +17,18 @@ public abstract class AbstractPlantUMLExporter extends AbstractDiagramExporter {
     public static final String PLANTUML_LEGEND_PROPERTY = "plantuml.legend";
     public static final String PLANTUML_INCLUDES_PROPERTY = "plantuml.includes";
     public static final String PLANTUML_SEQUENCE_DIAGRAMS_PROPERTY = "plantuml.sequenceDiagrams";
+
+    /**
+     * <p>Set this property to <code>true</code> by calling {@link Configuration#addProperty(String, String)} in your
+     * {@link ViewSet} in order to have all {@link ModelItem#getProperties()} (for {@link Component}s and
+     * {@link Relationship}s) being printed in the PlantUML diagrams.</p>
+     *
+     * <p>The default value is <code>false</code>.</p>
+     *
+     * @see ViewSet#getConfiguration()
+     * @see Configuration#getProperties()
+     */
+    public static final String PLANTUML_ADD_PROPERTIES_PROPERTY = "plantuml.addProperties";
 
     private final Map<String, String> skinParams = new LinkedHashMap<>();
 

--- a/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
@@ -6,6 +6,8 @@ import com.structurizr.model.*;
 import com.structurizr.util.StringUtils;
 import com.structurizr.view.*;
 
+import java.util.Map;
+
 import static java.lang.String.format;
 
 public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
@@ -179,6 +181,8 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
             url = "";
         }
 
+        addProperties(view, writer, element);
+
         if (element instanceof StaticStructureElementInstance) {
             StaticStructureElementInstance elementInstance = (StaticStructureElementInstance)element;
             element = elementInstance.getElement();
@@ -287,6 +291,8 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
             return;
         }
 
+        addProperties(view, writer, relationship);
+
         if (relationshipView.isResponse() != null && relationshipView.isResponse()) {
             source = relationship.getDestination();
             destination = relationship.getSource();
@@ -307,4 +313,15 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
         }
     }
 
+    private void addProperties(View view, IndentingWriter writer, ModelItem element) {
+        if ("true".equalsIgnoreCase(view.getViewSet().getConfiguration().getProperties().getOrDefault(PLANTUML_ADD_PROPERTIES_PROPERTY, "false"))) {
+            Map<String, String> properties = element.getProperties();
+            if (!properties.isEmpty()) {
+                writer.writeLine("WithoutPropertyHeader()");
+                properties.keySet().stream().sorted().forEach(key ->
+                        writer.writeLine(String.format("AddProperty(\"%s\",\"%s\")", key, properties.get(key)))
+                );
+            }
+        }
+    }
 }

--- a/src/test/java/com/structurizr/export/plantuml/C4PlantUMLDiagramExporterTests.java
+++ b/src/test/java/com/structurizr/export/plantuml/C4PlantUMLDiagramExporterTests.java
@@ -325,4 +325,28 @@ public class C4PlantUMLDiagramExporterTests extends AbstractExporterTests {
                 "SHOW_LEGEND()\n" +
                 "@enduml", diagram.getDefinition());
     }
+
+    @Test
+    public void test_printProperties() throws Exception {
+        Workspace workspace = new Workspace("Name", "Description");
+        SoftwareSystem softwareSystem = workspace.getModel().addSoftwareSystem("SoftwareSystem");
+        Container container1 = softwareSystem.addContainer("Container 1");
+        container1.addProperty("IP", "127.0.0.1");
+        container1.addProperty("Region", "East");
+        Container container2 = softwareSystem.addContainer("Container 2");
+        container2.addProperty("Region", "West");
+        container2.addProperty("IP", "127.0.0.2");
+        Relationship relationship = container1.uses(container2, "");
+        relationship.addProperty("Prop1", "Value1");
+        relationship.addProperty("Prop2", "Value2");
+
+        workspace.getViews().getConfiguration().addProperty(C4PlantUMLExporter.PLANTUML_ADD_PROPERTIES_PROPERTY, "true");
+        ContainerView view = workspace.getViews().createContainerView(softwareSystem, "containerView", "");
+        view.addDefaultElements();
+
+        Diagram diagram = new C4PlantUMLExporter().export(view);
+
+        String expected = readFile(new File("./src/test/java/com/structurizr/export/plantuml/c4plantuml/printProperties-containerView.puml"));
+        assertEquals(expected, diagram.getDefinition());
+    }
 }

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/printProperties-containerView.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/printProperties-containerView.puml
@@ -1,0 +1,27 @@
+@startuml
+title SoftwareSystem - Containers
+
+top to bottom direction
+
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4.puml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+
+System_Boundary("SoftwareSystem_boundary", "SoftwareSystem") {
+  WithoutPropertyHeader()
+  AddProperty("IP","127.0.0.1")
+  AddProperty("Region","East")
+  Container(SoftwareSystem.Container1, "Container 1", "", $tags="Element+Container")
+  WithoutPropertyHeader()
+  AddProperty("IP","127.0.0.2")
+  AddProperty("Region","West")
+  Container(SoftwareSystem.Container2, "Container 2", "", $tags="Element+Container")
+}
+
+WithoutPropertyHeader()
+AddProperty("Prop1","Value1")
+AddProperty("Prop2","Value2")
+Rel_D(SoftwareSystem.Container1, SoftwareSystem.Container2, "", $tags="Relationship")
+
+SHOW_LEGEND()
+@enduml


### PR DESCRIPTION
This PR would be a solution for #2 by adding properties to elements and relationships.

The resulting diagram would look like that:

![image](https://user-images.githubusercontent.com/172195/161937179-64c74ad9-bab0-43ef-9de1-69c360b82a86.png)

This functionality needs to be explicitely enabled by setting `com.structurizr.export.plantuml.AbstractPlantUMLExporter#PLANTUML_ADD_PROPERTIES_PROPERTY` to `true`
