### PR TITLE
Add support for relationship direction.

### DIFF
--- a/src/main/java/com/structurizr/export/plantuml/StructurizrPlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/StructurizrPlantUMLExporter.java
@@ -366,6 +366,17 @@ public class StructurizrPlantUMLExporter extends AbstractPlantUMLExporter {
             String arrowStart;
             String arrowEnd;
             String relationshipStyle = style.getColor();
+            String direction = "";
+
+            if (relationship.hasTag("right")) {
+                direction = "right";
+            } else if (relationship.hasTag("left")) {
+                direction = "left";
+            } else if (relationship.hasTag("up")) {
+                direction = "up";
+            } else if (relationship.hasTag("down")) {
+                direction = "down";
+            }
 
             if (style.getThickness() != null) {
                 relationshipStyle += ",thickness=" + style.getThickness();
@@ -383,11 +394,12 @@ public class StructurizrPlantUMLExporter extends AbstractPlantUMLExporter {
                 relationshipStyle = "hidden";
             }
 
-            // 1 .[#rrggbb,thickness=n].> 2 : "...\n<size:8>...</size>
+            // 1 .[#rrggbb,thickness=n]direction.> 2 : "...\n<size:8>...</size>
             writer.writeLine(format("%s %s[%s]%s %s : \"<color:%s>%s%s\"",
                     idOf(relationship.getSource()),
                     arrowStart,
                     relationshipStyle,
+                    direction,
                     arrowEnd,
                     idOf(relationship.getDestination()),
                     style.getColor(),


### PR DESCRIPTION
When using the Structurizr PlantUML exporter with autolayout, the result is not always satisfying.

PlantUML component diagrams support hints for the layout by means of arrow directions, see Changing Arrow Direction in https://plantuml.com/component-diagram.

This pull request is a proof of concept that use tags associated to relationship for setting up those hints:

```
foo -> bar: "name" "" "right"
```

Will generate
```
foo .[#707070,thickness=2]right.> bar : "<color:#707070>Uses"
```

It's code I use in a custom exporter but I think it would be useful as an upstream feature. I understand the real solution would involve adding a `direction` attribute to relationship styles instead of using tag (maybe `plantumlDirection` to make it clear it's just a plantUML thing). I thought it would be clearer to propose this new feature in this way then just creating an issue.

Thanks for considering this and for all your work on Structurizr!