### PR TITLE
Add C4-PlantUML Properties to Deployment_Nodes

### DIFF
--- a/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
@@ -289,6 +289,10 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
             url = "";
         }
 
+        if (Boolean.TRUE.toString().equalsIgnoreCase(view.getViewSet().getConfiguration().getProperties().getOrDefault(C4PLANTUML_ELEMENT_PROPERTIES_PROPERTY, Boolean.FALSE.toString()))) {
+            addProperties(view, writer, deploymentNode);
+        }
+
         if (StringUtils.isNullOrEmpty(deploymentNode.getTechnology())) {
             writer.writeLine(
                     format("Deployment_Node(%s, \"%s\", $tags=\"%s\")%s {",

--- a/src/test/java/com/structurizr/export/plantuml/C4PlantUMLDiagramExporterTests.java
+++ b/src/test/java/com/structurizr/export/plantuml/C4PlantUMLDiagramExporterTests.java
@@ -366,6 +366,26 @@ public class C4PlantUMLDiagramExporterTests extends AbstractExporterTests {
     }
 
     @Test
+    public void test_deploymentViewPrintProperties() throws Exception {
+        Workspace workspace = new Workspace("Name", "Description");
+
+        DeploymentNode deploymentNode = workspace.getModel().addDeploymentNode("Deployment node");
+        deploymentNode.addProperty("Prop1", "Value1");
+
+        InfrastructureNode infraNode = deploymentNode.addInfrastructureNode("Infrastructure node", "description", "technology");
+        infraNode.addProperty("Prop2", "Value2");
+
+        workspace.getViews().getConfiguration().addProperty(C4PlantUMLExporter.C4PLANTUML_ELEMENT_PROPERTIES_PROPERTY, Boolean.TRUE.toString());
+        DeploymentView deploymentView = workspace.getViews().createDeploymentView("deploymentView", "");
+        deploymentView.addDefaultElements();
+
+        Diagram diagram = new C4PlantUMLExporter().export(deploymentView);
+
+        String expected = readFile(new File("./src/test/java/com/structurizr/export/plantuml/c4plantuml/printProperties-deploymentView.puml"));
+        assertEquals(expected, diagram.getDefinition());
+    }
+
+    @Test
     public void test_legendAndStereotypes() {
         Workspace workspace = new Workspace("Name", "Description");
         workspace.getModel().addSoftwareSystem("Name");

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/printProperties-deploymentView.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/printProperties-deploymentView.puml
@@ -1,0 +1,20 @@
+@startuml
+title Deployment - Default
+
+top to bottom direction
+
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4.puml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Deployment.puml
+
+WithoutPropertyHeader()
+AddProperty("Prop1","Value1")
+Deployment_Node(Default.Deploymentnode, "Deployment node", $tags="") {
+  WithoutPropertyHeader()
+  AddProperty("Prop2","Value2")
+  Deployment_Node(Default.Deploymentnode.Infrastructurenode, "Infrastructure node", "technology", "description", $tags="")
+}
+
+
+SHOW_LEGEND(true)
+@enduml


### PR DESCRIPTION
Because of the way Deployment Nodes were rendered, the code path to add C4-PlantUML AddProperty Attributes was not being called.

This change adds a check to see if the `c4plantuml.elementProperties` property has been set in the `startDeploymentNodeBoundary` method to ensure any model properties assigned to Deployment Nodes will also be rendered on exported C4-PlantUML diagrams.

This is an addition to the old behaviour where the properties were only rendered on container views.