### PR TITLE
Swallow UnsatisfiedLinkErrors in calculateIconScale

### DIFF
--- a/src/main/java/com/structurizr/export/plantuml/StructurizrPlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/StructurizrPlantUMLExporter.java
@@ -602,7 +602,7 @@ public class StructurizrPlantUMLExporter extends AbstractPlantUMLExporter {
             int height = bi.getHeight();
 
             scale = MAX_ICON_SIZE / Math.max(width, height);
-        } catch (UnsatisfiedLinkError e) {
+        } catch (UnsatisfiedLinkError | IIOException e) {
             // This is a known issue on native builds since AWT packages aren't available.
             // So we just swallow the error and use the default scale            
         } catch (Exception e) {

--- a/src/main/java/com/structurizr/export/plantuml/StructurizrPlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/StructurizrPlantUMLExporter.java
@@ -602,6 +602,9 @@ public class StructurizrPlantUMLExporter extends AbstractPlantUMLExporter {
             int height = bi.getHeight();
 
             scale = MAX_ICON_SIZE / Math.max(width, height);
+        } catch (UnsatisfiedLinkError e) {
+            // This is a known issue on native builds since AWT packages aren't available.
+            // So we just swallow the error and use the default scale            
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
java.awt.image.BufferedImage is used to determine the icon size here but this is not available on the classpath currently in graalvm builds.

There is currently an UnsatisfiedLinkError that is thrown when this happens but since the try/catch handler is only catching Exception, this isn't caught.

So we swallow UnsatisfiedLinkErrors rather than printing the stacktrace in that case, since this is a known error and not one we'd want to spam the logs for.

Resolves #47 