### PR TITLE
Support Cylinder and Pipe component shapes in C4PlantUMLExporter

### DIFF
--- a/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
@@ -454,10 +454,17 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
             }
         } else if (element instanceof Component) {
             Component component = (Component)element;
+            String shape = "";
+            if (elementStyle.getShape() == Shape.Cylinder) {
+                shape = "Db";
+            } else if (elementStyle.getShape() == Shape.Pipe) {
+                shape = "Queue";
+            }
+
             if (StringUtils.isNullOrEmpty(component.getTechnology())) {
-                writer.writeLine(String.format("Component(%s, \"%s\", \"%s\", $tags=\"%s\")%s", id, name, description, tagsOf(view, elementToWrite), url));
+                writer.writeLine(String.format("Component%s(%s, \"%s\", \"%s\", $tags=\"%s\")%s", shape, id, name, description, tagsOf(view, elementToWrite), url));
             } else {
-                writer.writeLine(String.format("Component(%s, \"%s\", \"%s\", \"%s\", $tags=\"%s\")%s", id, name, component.getTechnology(), description, tagsOf(view, elementToWrite), url));
+                writer.writeLine(String.format("Component%s(%s, \"%s\", \"%s\", \"%s\", $tags=\"%s\")%s", shape, id, name, component.getTechnology(), description, tagsOf(view, elementToWrite), url));
             }
         } else if (element instanceof InfrastructureNode) {
             InfrastructureNode infrastructureNode = (InfrastructureNode)element;

--- a/src/test/java/com/structurizr/export/plantuml/C4PlantUMLDiagramExporterTests.java
+++ b/src/test/java/com/structurizr/export/plantuml/C4PlantUMLDiagramExporterTests.java
@@ -484,6 +484,101 @@ public class C4PlantUMLDiagramExporterTests extends AbstractExporterTests {
     }
 
     @Test
+    public void test_renderContainerShapes() throws Exception {
+        Workspace workspace = new Workspace("Name", "Description");
+        SoftwareSystem softwareSystem = workspace.getModel().addSoftwareSystem("Software System");
+
+        Container container1 = softwareSystem.addContainer("Default Container");
+        Container container2 = softwareSystem.addContainer("Cylinder Container");
+        Container container3 = softwareSystem.addContainer("Pipe Container");
+        Container container4 = softwareSystem.addContainer("Robot Container");
+        container2.addTags("Cylinder");
+        container3.addTags("Pipe");
+        container4.addTags("Robot"); // Just an example of a shape that has no C4-PlantUML mapping.
+
+        ContainerView containerView = workspace.getViews().createContainerView(softwareSystem, "Containers", "");
+        containerView.add(container1);
+        containerView.add(container2);
+        containerView.add(container3);
+        containerView.add(container4);
+
+        workspace.getViews().getConfiguration().getStyles().addElementStyle("Cylinder").shape(Shape.Cylinder);
+        workspace.getViews().getConfiguration().getStyles().addElementStyle("Pipe").shape(Shape.Pipe);
+        workspace.getViews().getConfiguration().getStyles().addElementStyle("Robot").shape(Shape.Robot);
+
+        Diagram diagram = new C4PlantUMLExporter().export(containerView);
+        assertEquals("@startuml\n" +
+                "set separator none\n" +
+                "title Software System - Containers\n" +
+                "\n" +
+                "top to bottom direction\n" +
+                "\n" +
+                "!include <C4/C4>\n" +
+                "!include <C4/C4_Context>\n" +
+                "!include <C4/C4_Container>\n" +
+                "\n" +
+                "System_Boundary(\"SoftwareSystem_boundary\", \"Software System\", $tags=\"\") {\n" +
+                "  Container(SoftwareSystem.DefaultContainer, \"Default Container\", \"\", $tags=\"\")\n" +
+                "  ContainerDb(SoftwareSystem.CylinderContainer, \"Cylinder Container\", \"\", $tags=\"\")\n" +
+                "  ContainerQueue(SoftwareSystem.PipeContainer, \"Pipe Container\", \"\", $tags=\"\")\n" +
+                "  Container(SoftwareSystem.RobotContainer, \"Robot Container\", \"\", $tags=\"\")\n" +
+                "}\n" +
+                "\n" +
+                "\n" +
+                "SHOW_LEGEND(true)\n" +
+                "@enduml", diagram.getDefinition());
+    }
+
+    @Test
+    public void test_renderComponentShapes() throws Exception {
+        Workspace workspace = new Workspace("Name", "Description");
+        SoftwareSystem softwareSystem = workspace.getModel().addSoftwareSystem("Software System");
+        Container container = softwareSystem.addContainer("Container");
+
+        Component component1 = container.addComponent("Default Component");
+        Component component2 = container.addComponent("Cylinder Component");
+        Component component3 = container.addComponent("Pipe Component");
+        Component component4 = container.addComponent("Robot Component");
+
+        component2.addTags("Cylinder");
+        component3.addTags("Pipe");
+        component4.addTags("Robot"); // Just an example of a shape that has no C4-PlantUML mapping.
+
+        ContainerView containerView = workspace.getViews().createContainerView(softwareSystem, "Containers", "");
+        ComponentView componentView = workspace.getViews().createComponentView(container, "Components", "");
+        componentView.add(component1);
+        componentView.add(component2);
+        componentView.add(component3);
+        componentView.add(component4);
+
+        workspace.getViews().getConfiguration().getStyles().addElementStyle("Cylinder").shape(Shape.Cylinder);
+        workspace.getViews().getConfiguration().getStyles().addElementStyle("Pipe").shape(Shape.Pipe);
+        workspace.getViews().getConfiguration().getStyles().addElementStyle("Robot").shape(Shape.Robot);
+
+        Diagram diagram = new C4PlantUMLExporter().export(componentView);
+        assertEquals("@startuml\n" +
+                "set separator none\n" +
+                "title Software System - Container - Components\n" +
+                "\n" +
+                "top to bottom direction\n" +
+                "\n" +
+                "!include <C4/C4>\n" +
+                "!include <C4/C4_Context>\n" +
+                "!include <C4/C4_Component>\n" +
+                "\n" +
+                "Container_Boundary(\"SoftwareSystem.Container_boundary\", \"Container\", $tags=\"\") {\n" +
+                "  Component(SoftwareSystem.Container.DefaultComponent, \"Default Component\", \"\", $tags=\"\")\n" +
+                "  ComponentDb(SoftwareSystem.Container.CylinderComponent, \"Cylinder Component\", \"\", $tags=\"\")\n" +
+                "  ComponentQueue(SoftwareSystem.Container.PipeComponent, \"Pipe Component\", \"\", $tags=\"\")\n" +
+                "  Component(SoftwareSystem.Container.RobotComponent, \"Robot Component\", \"\", $tags=\"\")\n" +
+                "}\n" +
+                "\n" +
+                "\n" +
+                "SHOW_LEGEND(true)\n" +
+                "@enduml", diagram.getDefinition());
+    }
+
+    @Test
     public void testFont() {
         Workspace workspace = new Workspace("Name", "Description");
         workspace.getModel().addPerson("User");


### PR DESCRIPTION
## Overview

This change updates the C4-PlantUML exporter to use [C4-PlantUML](https://github.com/plantuml-stdlib/C4-PlantUML)'s [ComponentDb](https://github.com/plantuml-stdlib/C4-PlantUML/blob/0fac3286958dc0d27a658ebba11c2f8accdb0fd2/C4_Component.puml#L65) and [ComponentQueue](https://github.com/plantuml-stdlib/C4-PlantUML/blob/0fac3286958dc0d27a658ebba11c2f8accdb0fd2/C4_Component.puml#L69) for Structurizr's `Cylinder` and `Pipe` shapes respectively (#59).  The exporter already does this for _containers_, this change simply replicates that for _components_ too.

## Testing

I've added appropriate test for the new logic. I'm not entirely sure that the tests use best-practices (I'm no Java developer), but as much as possible I've tried to follow the patterns and conventions of the existing tests 😇

I also added a test for the existing _container_ shapes support. The Cylinder support was being testing implicitly (by the "Big Bank plc" example), but the Pipe support was not being testing at all.

## PUML Diff

Here's a simple diff showing the change in generated PUML:

```diff
--- before.puml 2023-06-03 11:42:29.657670020 +1000
+++ after.puml  2023-06-03 11:42:11.969731326 +1000
@@ -10,8 +10,8 @@
 
 Container_Boundary("SoftwareSystem.Container_boundary", "Container", $tags="") {
   Component(SoftwareSystem.Container.DefaultComponent, "Default Component", "", $tags="")
-  Component(SoftwareSystem.Container.CylinderComponent, "Cylinder Component", "", $tags="")
-  Component(SoftwareSystem.Container.PipeComponent, "Pipe Component", "", $tags="")
+  ComponentDb(SoftwareSystem.Container.CylinderComponent, "Cylinder Component", "", $tags="")
+  ComponentQueue(SoftwareSystem.Container.PipeComponent, "Pipe Component", "", $tags="")
   Component(SoftwareSystem.Container.RobotComponent, "Robot Component", "", $tags="")
 }
```

## Renders

Here's how the embedded test example renders before and after the change.

[Before](https://www.plantuml.com/plantuml/uml/fSx1IiD040RW-pp563oaeFNIevPYMlGWAlRWCMoQgIniPiBkB1h4TpUfRH8KHUXjvj_PRsOHr7YDbOD0Ye5guusAHnOcKAkES2rRVJM-BPgWLE4vPi9gB9FVrLKjJAm1GAL65In4LIeihQUDMc604yiR5ql2osnsaStctuEy4-bDVpxq_1oWNvjVI-JI-2PD3iTztJOTHehzI7A6IP-spQcQbt2L91Dy1nokJt-3falQckYqdsozVJJyxfQCxV_9MUCib-J7z24xrdwqDOtThZ_MV992T8pkWZ_K3m1OtpuyvtUhczNzCbKVQG8BuZ9MxXC0):

![image](https://github.com/structurizr/export/assets/5195222/fdf36411-70bc-4dac-8362-907e40e757ed)

[After](https://www.plantuml.com/plantuml/uml/ZSwzJiD030VmtKzX8ePMWh9q15IHLZ0WFkZ0M5qQ5vrqiQCxdo12l3j9QJu42kfs_jltinT1ZTTOE0Ya6AWqtgXuP642jUe8rxBJT-FhHnMK2Zp7L5YDPVBxTr4A4si0K2bH1JDHbG9pwschLXZWnFBMnPpmCfrVfFFhty6c4Ub3_pPQlcv1jtPp8v5puwj9qXxtSzki7yaE8yaP9brQ5wTgti9Laapn4x2_VZ86pPQqCz5fDrbxXwZ_tImPsaDvcOtRQUKiv-I7U9iTfpz7YZI-uCcMDCIR-ZXut7oHJ7I8xeD_r2y0MDyzlcxkLxUhX-L4VQGfB8ZpMBXl):

![image](https://github.com/structurizr/export/assets/5195222/8e47d215-1312-4537-98a3-7cb81b3f94ba)

Cheers.