### PR TITLE
Swallow UnsupportedOperationException for Graal native env

### DIFF
--- a/src/main/java/com/structurizr/export/plantuml/StructurizrPlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/StructurizrPlantUMLExporter.java
@@ -602,7 +602,7 @@ public class StructurizrPlantUMLExporter extends AbstractPlantUMLExporter {
             int height = bi.getHeight();
 
             scale = MAX_ICON_SIZE / Math.max(width, height);
-        } catch (UnsatisfiedLinkError | IIOException e) {
+        } catch (UnsupportedOperationException | UnsatisfiedLinkError | IIOException e) {
             // This is a known issue on native builds since AWT packages aren't available.
             // So we just swallow the error and use the default scale            
         } catch (Exception e) {


### PR DESCRIPTION
In a Graal native environment, Quarkus will throw UnsupportedOperationException (if the AWT extension, which isn't supported by graal, isn't installed) in this case, we can safely swallow the exception and use the default

See: https://github.com/quarkusio/quarkus/blob/c837ba5f56ea3ff63128ba43d2994ecdae690baa/core/runtime/src/main/java/io/quarkus/runtime/graal/AwtImageIO.java#L66