### PR TITLE
Added BorderStyle and BorderThickness to C4PlantUML Exporter

### DIFF
--- a/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
+++ b/src/main/java/com/structurizr/export/plantuml/C4PlantUMLExporter.java
@@ -172,13 +172,20 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
                     }
                     sprite = elementStyle.getProperties().getOrDefault(C4PLANTUML_SPRITE, sprite);
 
-                    writer.writeLine(String.format("AddElementTag(\"%s\", $bgColor=\"%s\", $borderColor=\"%s\", $fontColor=\"%s\", $sprite=\"%s\", $shadowing=\"%s\")",
+                    int borderThickness = 1;
+                    if (elementStyle.getStrokeWidth() != null) {
+                        borderThickness = elementStyle.getStrokeWidth();
+                    }
+
+                    writer.writeLine(String.format("AddElementTag(\"%s\", $bgColor=\"%s\", $borderColor=\"%s\", $fontColor=\"%s\", $sprite=\"%s\", $shadowing=\"%s\", $borderStyle=\"%s\", $borderThickness=\"%s\")",
                             tagList,
                             elementStyle.getBackground(),
                             elementStyle.getStroke(),
                             elementStyle.getColor(),
                             sprite,
-                            elementStyle.getProperties().getOrDefault(C4PLANTUML_SHADOW, "")
+                            elementStyle.getProperties().getOrDefault(C4PLANTUML_SHADOW, ""),
+                            elementStyle.getBorder(),
+                            borderThickness
                     ));
                 }
             }
@@ -213,12 +220,19 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
                     ElementStyle elementStyle = boundaryStyles.get(tagList);
                     tagList = tagList.replaceFirst("Element,", "");
 
-                    writer.writeLine(String.format("AddBoundaryTag(\"%s\", $bgColor=\"%s\", $borderColor=\"%s\", $fontColor=\"%s\", $shadowing=\"%s\")",
+                    int borderThickness = 1;
+                    if (elementStyle.getStrokeWidth() != null) {
+                        borderThickness = elementStyle.getStrokeWidth();
+                    }
+
+                    writer.writeLine(String.format("AddBoundaryTag(\"%s\", $bgColor=\"%s\", $borderColor=\"%s\", $fontColor=\"%s\", $shadowing=\"%s\", $borderStyle=\"%s\", $borderThickness=\"%s\")",
                             tagList,
                             "#ffffff",
                             elementStyle.getStroke(),
                             elementStyle.getStroke(),
-                            elementStyle.getProperties().getOrDefault(C4PLANTUML_SHADOW, "")
+                            elementStyle.getProperties().getOrDefault(C4PLANTUML_SHADOW, ""),
+                            elementStyle.getBorder(),
+                            borderThickness
                     ));
                 }
             }
@@ -264,6 +278,8 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
         }
 
         String color = "#cccccc";
+        String borderStyle = "Dashed";
+        int borderThickness = 1;
 //        String icon = "";
 
         ElementStyle elementStyleForGroup = view.getViewSet().getConfiguration().getStyles().findElementStyle("Group:" + group);
@@ -274,6 +290,19 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
         } else if (elementStyleForAllGroups != null && !StringUtils.isNullOrEmpty(elementStyleForAllGroups.getColor())) {
             color = elementStyleForAllGroups.getColor();
         }
+
+        if (elementStyleForGroup != null && !StringUtils.isNullOrEmpty(elementStyleForGroup.getStroke())) {
+            borderStyle = elementStyleForGroup.getStroke();
+        } else if (elementStyleForAllGroups != null && !StringUtils.isNullOrEmpty(elementStyleForAllGroups.getStroke())) {
+            borderStyle = elementStyleForAllGroups.getStroke();
+        }
+
+        if (elementStyleForGroup != null && elementStyleForGroup.getStrokeWidth() != null) {
+            borderThickness = elementStyleForGroup.getStrokeWidth();
+        } else if (elementStyleForAllGroups != null && elementStyleForAllGroups.getStrokeWidth() != null) {
+            borderThickness = elementStyleForAllGroups.getStrokeWidth();
+        }
+
 
 // todo: $sprite doesn't seem to be supported for boundary styles
 //        if (elementStyleForGroup != null && elementStyleHasSupportedIcon(elementStyleForGroup)) {
@@ -287,10 +316,12 @@ public class C4PlantUMLExporter extends AbstractPlantUMLExporter {
 //            icon = "\\n\\n<img:" + icon + "{scale=" + scale + "}>";
 //        }
 
-        writer.writeLine(String.format("AddBoundaryTag(\"%s\", $borderColor=\"%s\", $fontColor=\"%s\")",
+        writer.writeLine(String.format("AddBoundaryTag(\"%s\", $borderColor=\"%s\", $fontColor=\"%s\", $borderStyle=\"%s\", $borderThickness=\"%s\")",
                 group,
                 color,
-                color)
+                color,
+                borderStyle,
+                borderThickness)
         );
 
         writer.writeLine(String.format("Boundary(group_%s, \"%s\", $tags=\"%s\") {", groupId, groupName, group));

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-Components.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-Components.puml
@@ -9,15 +9,15 @@ top to bottom direction
 !include <C4/C4_Container>
 !include <C4/C4_Component>
 
-AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Component", $bgColor="#85bbf0", $borderColor="#5d82a8", $fontColor="#000000", $sprite="", $shadowing="")
-AddElementTag("Container,Mobile App", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container,Database", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container,Web Browser", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
+AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Component", $bgColor="#85bbf0", $borderColor="#5d82a8", $fontColor="#000000", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Mobile App", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Database", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Web Browser", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 AddRelTag("Relationship", $textColor="#707070", $lineColor="#707070", $lineStyle = "")
 
-AddBoundaryTag("Container", $bgColor="#ffffff", $borderColor="#2e6295", $fontColor="#2e6295", $shadowing="")
+AddBoundaryTag("Container", $bgColor="#ffffff", $borderColor="#2e6295", $fontColor="#2e6295", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 System(MainframeBankingSystem, "Mainframe Banking System", $descr="Stores all of the core banking information about customers, accounts, transactions, etc.", $tags="Software System,Existing System", $link="")
 Container(InternetBankingSystem.SinglePageApplication, "Single-Page Application", $techn="JavaScript and Angular", $descr="Provides all of the Internet banking functionality to customers via their web browser.", $tags="Container,Web Browser", $link="")

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-Containers.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-Containers.puml
@@ -8,16 +8,16 @@ top to bottom direction
 !include <C4/C4_Context>
 !include <C4/C4_Container>
 
-AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container,Mobile App", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container,Database", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Person", $bgColor="#08427b", $borderColor="#052e56", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container,Web Browser", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
+AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Mobile App", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Database", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Person", $bgColor="#08427b", $borderColor="#052e56", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Web Browser", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 AddRelTag("Relationship", $textColor="#707070", $lineColor="#707070", $lineStyle = "")
 
-AddBoundaryTag("Software System", $bgColor="#ffffff", $borderColor="#0b4884", $fontColor="#0b4884", $shadowing="")
+AddBoundaryTag("Software System", $bgColor="#ffffff", $borderColor="#0b4884", $fontColor="#0b4884", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 Person_Ext(PersonalBankingCustomer, "Personal Banking Customer", $descr="A customer of the bank, with personal bank accounts.", $tags="Person", $link="")
 System(MainframeBankingSystem, "Mainframe Banking System", $descr="Stores all of the core banking information about customers, accounts, transactions, etc.", $tags="Software System,Existing System", $link="")

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-DevelopmentDeployment.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-DevelopmentDeployment.puml
@@ -9,11 +9,11 @@ top to bottom direction
 !include <C4/C4_Container>
 !include <C4/C4_Deployment>
 
-AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Element", $bgColor="#ffffff", $borderColor="#888888", $fontColor="#000000", $sprite="", $shadowing="")
-AddElementTag("Container,Database", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container,Web Browser", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
+AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Element", $bgColor="#ffffff", $borderColor="#888888", $fontColor="#000000", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Database", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Web Browser", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 AddRelTag("Relationship", $textColor="#707070", $lineColor="#707070", $lineStyle = "")
 

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-LiveDeployment.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-LiveDeployment.puml
@@ -9,14 +9,14 @@ top to bottom direction
 !include <C4/C4_Container>
 !include <C4/C4_Deployment>
 
-AddElementTag("Failover", $bgColor="#ffffff", $borderColor="#888888", $fontColor="#000000", $sprite="", $shadowing="")
-AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Element", $bgColor="#ffffff", $borderColor="#888888", $fontColor="#000000", $sprite="", $shadowing="")
-AddElementTag("Container,Mobile App", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container,Database,Failover", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container,Database", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container,Web Browser", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
+AddElementTag("Failover", $bgColor="#ffffff", $borderColor="#888888", $fontColor="#000000", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Element", $bgColor="#ffffff", $borderColor="#888888", $fontColor="#000000", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Mobile App", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Database,Failover", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Database", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Web Browser", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 AddRelTag("Failover", $textColor="#707070", $lineColor="#707070", $lineStyle = "")
 AddRelTag("Relationship", $textColor="#707070", $lineColor="#707070", $lineStyle = "")

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-SignIn.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-SignIn.puml
@@ -9,13 +9,13 @@ top to bottom direction
 !include <C4/C4_Container>
 !include <C4/C4_Component>
 
-AddElementTag("Component", $bgColor="#85bbf0", $borderColor="#5d82a8", $fontColor="#000000", $sprite="", $shadowing="")
-AddElementTag("Container,Database", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Container,Web Browser", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="")
+AddElementTag("Component", $bgColor="#85bbf0", $borderColor="#5d82a8", $fontColor="#000000", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Database", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Web Browser", $bgColor="#438dd5", $borderColor="#2e6295", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 AddRelTag("Relationship", $textColor="#707070", $lineColor="#707070", $lineStyle = "")
 
-AddBoundaryTag("Container", $bgColor="#ffffff", $borderColor="#2e6295", $fontColor="#2e6295", $shadowing="")
+AddBoundaryTag("Container", $bgColor="#ffffff", $borderColor="#2e6295", $fontColor="#2e6295", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 Container_Boundary("InternetBankingSystem.APIApplication_boundary", "API Application", $tags="Container") {
   Component(InternetBankingSystem.APIApplication.SignInController, "Sign In Controller", $techn="Spring MVC Rest Controller", $descr="Allows users to sign in to the Internet Banking System.", $tags="Component", $link="")

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-SystemContext.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-SystemContext.puml
@@ -7,9 +7,9 @@ top to bottom direction
 !include <C4/C4>
 !include <C4/C4_Context>
 
-AddElementTag("Software System", $bgColor="#1168bd", $borderColor="#0b4884", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Person", $bgColor="#08427b", $borderColor="#052e56", $fontColor="#ffffff", $sprite="", $shadowing="")
+AddElementTag("Software System", $bgColor="#1168bd", $borderColor="#0b4884", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Person", $bgColor="#08427b", $borderColor="#052e56", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 AddRelTag("Relationship", $textColor="#707070", $lineColor="#707070", $lineStyle = "")
 

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-SystemLandscape.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/36141-SystemLandscape.puml
@@ -7,10 +7,10 @@ top to bottom direction
 !include <C4/C4>
 !include <C4/C4_Context>
 
-AddElementTag("Software System", $bgColor="#1168bd", $borderColor="#0b4884", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Person,Bank Staff", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="")
-AddElementTag("Person", $bgColor="#08427b", $borderColor="#052e56", $fontColor="#ffffff", $sprite="", $shadowing="")
+AddElementTag("Software System", $bgColor="#1168bd", $borderColor="#0b4884", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Person,Bank Staff", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Software System,Existing System", $bgColor="#999999", $borderColor="#6b6b6b", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Person", $bgColor="#08427b", $borderColor="#052e56", $fontColor="#ffffff", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 AddRelTag("Relationship", $textColor="#707070", $lineColor="#707070", $lineStyle = "")
 

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/54915-AmazonWebServicesDeployment-WithTags.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/54915-AmazonWebServicesDeployment-WithTags.puml
@@ -9,16 +9,16 @@ left to right direction
 !include <C4/C4_Container>
 !include <C4/C4_Deployment>
 
-AddElementTag("Container,Application", $bgColor="#ffffff", $borderColor="#b2b2b2", $fontColor="#000000", $sprite="", $shadowing="")
-AddElementTag("Amazon Web Services - RDS", $bgColor="#ffffff", $borderColor="#3b48cc", $fontColor="#3b48cc", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Amazon-RDS_light-bg@4x.png{scale=0.1}", $shadowing="")
-AddElementTag("Amazon Web Services - Auto Scaling", $bgColor="#ffffff", $borderColor="#cc2264", $fontColor="#cc2264", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/AWS-Auto-Scaling_light-bg@4x.png{scale=0.1}", $shadowing="")
-AddElementTag("Amazon Web Services - Route 53", $bgColor="#ffffff", $borderColor="#693cc5", $fontColor="#693cc5", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Amazon-Route-53_light-bg@4x.png{scale=0.1}", $shadowing="")
-AddElementTag("Amazon Web Services - EC2", $bgColor="#ffffff", $borderColor="#d86613", $fontColor="#d86613", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Amazon-EC2_light-bg@4x.png{scale=0.1}", $shadowing="")
-AddElementTag("Amazon Web Services - Region", $bgColor="#ffffff", $borderColor="#147eba", $fontColor="#147eba", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Region_light-bg@4x.png{scale=0.21428571428571427}", $shadowing="")
-AddElementTag("Amazon Web Services - Elastic Load Balancing", $bgColor="#ffffff", $borderColor="#693cc5", $fontColor="#693cc5", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Elastic-Load-Balancing_light-bg@4x.png{scale=0.1}", $shadowing="")
-AddElementTag("Amazon Web Services - RDS MySQL instance", $bgColor="#ffffff", $borderColor="#3b48cc", $fontColor="#3b48cc", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Amazon-RDS_MySQL_instance_light-bg@4x.png{scale=0.15}", $shadowing="")
-AddElementTag("Container,Database", $bgColor="#ffffff", $borderColor="#b2b2b2", $fontColor="#000000", $sprite="", $shadowing="")
-AddElementTag("Amazon Web Services - Cloud", $bgColor="#ffffff", $borderColor="#232f3e", $fontColor="#232f3e", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/AWS-Cloud_light-bg@4x.png{scale=0.21428571428571427}", $shadowing="")
+AddElementTag("Container,Application", $bgColor="#ffffff", $borderColor="#b2b2b2", $fontColor="#000000", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Amazon Web Services - RDS", $bgColor="#ffffff", $borderColor="#3b48cc", $fontColor="#3b48cc", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Amazon-RDS_light-bg@4x.png{scale=0.1}", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Amazon Web Services - Auto Scaling", $bgColor="#ffffff", $borderColor="#cc2264", $fontColor="#cc2264", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/AWS-Auto-Scaling_light-bg@4x.png{scale=0.1}", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Amazon Web Services - Route 53", $bgColor="#ffffff", $borderColor="#693cc5", $fontColor="#693cc5", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Amazon-Route-53_light-bg@4x.png{scale=0.1}", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Amazon Web Services - EC2", $bgColor="#ffffff", $borderColor="#d86613", $fontColor="#d86613", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Amazon-EC2_light-bg@4x.png{scale=0.1}", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Amazon Web Services - Region", $bgColor="#ffffff", $borderColor="#147eba", $fontColor="#147eba", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Region_light-bg@4x.png{scale=0.21428571428571427}", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Amazon Web Services - Elastic Load Balancing", $bgColor="#ffffff", $borderColor="#693cc5", $fontColor="#693cc5", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Elastic-Load-Balancing_light-bg@4x.png{scale=0.1}", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Amazon Web Services - RDS MySQL instance", $bgColor="#ffffff", $borderColor="#3b48cc", $fontColor="#3b48cc", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/Amazon-RDS_MySQL_instance_light-bg@4x.png{scale=0.15}", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Container,Database", $bgColor="#ffffff", $borderColor="#b2b2b2", $fontColor="#000000", $sprite="", $shadowing="", $borderStyle="Solid", $borderThickness="1")
+AddElementTag("Amazon Web Services - Cloud", $bgColor="#ffffff", $borderColor="#232f3e", $fontColor="#232f3e", $sprite="img:https://static.structurizr.com/themes/amazon-web-services-2020.04.30/AWS-Cloud_light-bg@4x.png{scale=0.21428571428571427}", $shadowing="", $borderStyle="Solid", $borderThickness="1")
 
 AddRelTag("Relationship", $textColor="#707070", $lineColor="#707070", $lineStyle = "")
 

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/group-styles-1.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/group-styles-1.puml
@@ -7,17 +7,17 @@ top to bottom direction
 !include <C4/C4>
 !include <C4/C4_Context>
 
-AddBoundaryTag("Group 1", $borderColor="#111111", $fontColor="#111111")
+AddBoundaryTag("Group 1", $borderColor="#111111", $fontColor="#111111", $borderStyle="Dashed", $borderThickness="1")
 Boundary(group_1, "Group 1", $tags="Group 1") {
   Person(User1, "User 1", $descr="", $tags="", $link="")
 }
 
-AddBoundaryTag("Group 2", $borderColor="#222222", $fontColor="#222222")
+AddBoundaryTag("Group 2", $borderColor="#222222", $fontColor="#222222", $borderStyle="Dashed", $borderThickness="1")
 Boundary(group_2, "Group 2", $tags="Group 2") {
   Person(User2, "User 2", $descr="", $tags="", $link="")
 }
 
-AddBoundaryTag("Group 3", $borderColor="#cccccc", $fontColor="#cccccc")
+AddBoundaryTag("Group 3", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
 Boundary(group_3, "Group 3", $tags="Group 3") {
   Person(User3, "User 3", $descr="", $tags="", $link="")
 }

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/group-styles-2.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/group-styles-2.puml
@@ -7,17 +7,17 @@ top to bottom direction
 !include <C4/C4>
 !include <C4/C4_Context>
 
-AddBoundaryTag("Group 1", $borderColor="#111111", $fontColor="#111111")
+AddBoundaryTag("Group 1", $borderColor="#111111", $fontColor="#111111", $borderStyle="Dashed", $borderThickness="1")
 Boundary(group_1, "Group 1", $tags="Group 1") {
   Person(User1, "User 1", $descr="", $tags="", $link="")
 }
 
-AddBoundaryTag("Group 2", $borderColor="#222222", $fontColor="#222222")
+AddBoundaryTag("Group 2", $borderColor="#222222", $fontColor="#222222", $borderStyle="Dashed", $borderThickness="1")
 Boundary(group_2, "Group 2", $tags="Group 2") {
   Person(User2, "User 2", $descr="", $tags="", $link="")
 }
 
-AddBoundaryTag("Group 3", $borderColor="#aabbcc", $fontColor="#aabbcc")
+AddBoundaryTag("Group 3", $borderColor="#aabbcc", $fontColor="#aabbcc", $borderStyle="Dashed", $borderThickness="1")
 Boundary(group_3, "Group 3", $tags="Group 3") {
   Person(User3, "User 3", $descr="", $tags="", $link="")
 }

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/groups-Components.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/groups-Components.puml
@@ -11,7 +11,7 @@ top to bottom direction
 System(C, "C", $descr="", $tags="", $link="")
 
 Container_Boundary("D.F_boundary", "F", $tags="") {
-  AddBoundaryTag("Group 4", $borderColor="#cccccc", $fontColor="#cccccc")
+  AddBoundaryTag("Group 4", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
   Boundary(group_1, "Group 4", $tags="Group 4") {
     Component(D.F.H, "H", $techn="", $descr="", $tags="", $link="")
   }

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/groups-Containers.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/groups-Containers.puml
@@ -11,7 +11,7 @@ top to bottom direction
 System(C, "C", $descr="", $tags="", $link="")
 
 System_Boundary("D_boundary", "D", $tags="") {
-  AddBoundaryTag("Group 3", $borderColor="#cccccc", $fontColor="#cccccc")
+  AddBoundaryTag("Group 3", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
   Boundary(group_1, "Group 3", $tags="Group 3") {
     Container(D.F, "F", $techn="", $descr="", $tags="", $link="")
   }

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/groups-SystemLandscape.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/groups-SystemLandscape.puml
@@ -8,7 +8,7 @@ top to bottom direction
 !include <C4/C4_Context>
 
 Enterprise_Boundary(enterprise, "Enterprise") {
-  AddBoundaryTag("Group 2", $borderColor="#cccccc", $fontColor="#cccccc")
+  AddBoundaryTag("Group 2", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
   Boundary(group_1, "Group 2", $tags="Group 2") {
     System(D, "D", $descr="", $tags="", $link="")
   }
@@ -16,7 +16,7 @@ Enterprise_Boundary(enterprise, "Enterprise") {
   System(C, "C", $descr="", $tags="", $link="")
 }
 
-AddBoundaryTag("Group 1", $borderColor="#cccccc", $fontColor="#cccccc")
+AddBoundaryTag("Group 1", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
 Boundary(group_2, "Group 1", $tags="Group 1") {
   System_Ext(B, "B", $descr="", $tags="", $link="")
 }

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/nested-groups-with-dot-separator.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/nested-groups-with-dot-separator.puml
@@ -7,11 +7,11 @@ top to bottom direction
 !include <C4/C4>
 !include <C4/C4_Context>
 
-AddBoundaryTag("Organisation 1", $borderColor="#cccccc", $fontColor="#cccccc")
+AddBoundaryTag("Organisation 1", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
 Boundary(group_1, "Organisation 1", $tags="Organisation 1") {
-    AddBoundaryTag("Organisation 1.Department 1", $borderColor="#cccccc", $fontColor="#cccccc")
+    AddBoundaryTag("Organisation 1.Department 1", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
     Boundary(group_2, "Department 1", $tags="Organisation 1.Department 1") {
-        AddBoundaryTag("Organisation 1.Department 1.Team 1", $borderColor="#cccccc", $fontColor="#cccccc")
+        AddBoundaryTag("Organisation 1.Department 1.Team 1", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
         Boundary(group_3, "Team 1", $tags="Organisation 1.Department 1.Team 1") {
           System(Team1, "Team 1", $descr="", $tags="", $link="")
         }

--- a/src/test/java/com/structurizr/export/plantuml/c4plantuml/nested-groups.puml
+++ b/src/test/java/com/structurizr/export/plantuml/c4plantuml/nested-groups.puml
@@ -7,18 +7,18 @@ top to bottom direction
 !include <C4/C4>
 !include <C4/C4_Context>
 
-AddBoundaryTag("Organisation 1", $borderColor="#cccccc", $fontColor="#cccccc")
+AddBoundaryTag("Organisation 1", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
 Boundary(group_1, "Organisation 1", $tags="Organisation 1") {
   System(Organisation1, "Organisation 1", $descr="", $tags="", $link="")
-    AddBoundaryTag("Organisation 1/Department 1", $borderColor="#cccccc", $fontColor="#cccccc")
+    AddBoundaryTag("Organisation 1/Department 1", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
     Boundary(group_2, "Department 1", $tags="Organisation 1/Department 1") {
       System(Department1, "Department 1", $descr="", $tags="", $link="")
-        AddBoundaryTag("Organisation 1/Department 1/Team 1", $borderColor="#cccccc", $fontColor="#cccccc")
+        AddBoundaryTag("Organisation 1/Department 1/Team 1", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
         Boundary(group_3, "Team 1", $tags="Organisation 1/Department 1/Team 1") {
           System(Team1, "Team 1", $descr="", $tags="", $link="")
         }
 
-        AddBoundaryTag("Organisation 1/Department 1/Team 2", $borderColor="#cccccc", $fontColor="#cccccc")
+        AddBoundaryTag("Organisation 1/Department 1/Team 2", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
         Boundary(group_4, "Team 2", $tags="Organisation 1/Department 1/Team 2") {
           System(Team2, "Team 2", $descr="", $tags="", $link="")
         }
@@ -27,7 +27,7 @@ Boundary(group_1, "Organisation 1", $tags="Organisation 1") {
 
 }
 
-AddBoundaryTag("Organisation 2", $borderColor="#cccccc", $fontColor="#cccccc")
+AddBoundaryTag("Organisation 2", $borderColor="#cccccc", $fontColor="#cccccc", $borderStyle="Dashed", $borderThickness="1")
 Boundary(group_5, "Organisation 2", $tags="Organisation 2") {
   System(Organisation2, "Organisation 2", $descr="", $tags="", $link="")
 }


### PR DESCRIPTION
This PR added two new attributes to elements and boundaries for the border style and thickness. By default these are set as 'solid' and '1' for elements and 'dashed' and '1' for boundaries.

Requires PlantUML 1.2023.11 which has just been released to be able to process the exported puml.

Screenshot of exported puml with border styles added :

![Screenshot 2023-09-15 at 9 28 33 AM](https://github.com/structurizr/export/assets/1433840/63669ac1-d9b4-4533-b8c8-8321d823ffda)

Resolves #73 